### PR TITLE
ENG-1059: Throw error from run-rerun

### DIFF
--- a/lib/command/run-rerun.js
+++ b/lib/command/run-rerun.js
@@ -17,10 +17,6 @@ module.exports = async function (test, options) {
   const testRoot = getTestRoot(configFile)
   createOutputDir(config, testRoot)
 
-  function processError(err) {
-    printError(err)
-    process.exit(1)
-  }
   const codecept = new Codecept(config, options)
 
   try {

--- a/lib/rerun.js
+++ b/lib/rerun.js
@@ -70,6 +70,7 @@ class CodeceptRerunner extends BaseCodecept {
       await this.runTests(test);
     } catch (e) {
       output.error(e.stack);
+      throw e;
     } finally {
       event.emit(event.all.result, this);
       event.emit(event.all.after, this);

--- a/test/data/sandbox/configs/run-rerun/codecept.conf.pass_all_test.js
+++ b/test/data/sandbox/configs/run-rerun/codecept.conf.pass_all_test.js
@@ -1,0 +1,16 @@
+exports.config = {
+  tests: './*_ftest.js',
+  output: './output',
+  helpers: {
+    CustomHelper: {
+      require: './customHelper.js',
+    },
+  },
+  rerun: {
+    minSuccess: 3,
+    maxReruns: 3,
+  },
+  bootstrap: null,
+  mocha: {},
+  name: 'run-rerun',
+};

--- a/test/runner/run_rerun_test.js
+++ b/test/runner/run_rerun_test.js
@@ -83,7 +83,7 @@ describe('run-rerun command', () => {
     )
   })
 
-  it('should display success run if test was fail one time of two attepmts and 3 reruns', (done) => {
+  it('should display success run if test was fail one time of two attempts and 3 reruns', (done) => {
     exec(
       `FAIL_ATTEMPT=0  ${codecept_run_config('codecept.conf.fail_test.js', '@RunRerun - fail second test')} --debug`,
       (err, stdout) => {
@@ -92,6 +92,20 @@ describe('run-rerun command', () => {
         expect(stdout).toContain('Process run 3 of max 3, success runs 2/2')
         expect(stdout).not.toContain('Flaky tests detected!')
         expect(err).toBeNull()
+        done()
+      },
+    )
+  })
+
+  it('should throw exit code 1 if all tests were supposed to pass', (done) => {
+    exec(
+      `FAIL_ATTEMPT=0  ${codecept_run_config('codecept.conf.pass_all_test.js', '@RunRerun - fail second test')} --debug`,
+      (err, stdout) => {
+        expect(stdout).toContain('Process run 1 of max 3, success runs 1/3')
+        expect(stdout).toContain('Fail run 2 of max 3, success runs 1/3')
+        expect(stdout).toContain('Process run 3 of max 3, success runs 2/3')
+        expect(stdout).toContain('Flaky tests detected!')
+        expect(err.code).toBe(1)
         done()
       },
     )


### PR DESCRIPTION
## Motivation/Description of the PR
This PR causes failures from run-rerun to be thrown. After some testing, the existing code in run-rerun will exit with an error code of 1 if the last-executed test fails but I wasn't able to pinpoint why exit code 1 wasn't being thrown if the first test (or any other test than the last one) failed. 

Note: I've also made a PR on the [CodeceptJS repo](https://github.com/codeceptjs/CodeceptJS/pull/4494).

Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
